### PR TITLE
Fix regex on RSA fingerprint check

### DIFF
--- a/lib/wizard.php
+++ b/lib/wizard.php
@@ -587,7 +587,7 @@ function wizard() {
 			break;
 		} elseif ($input == 'Y') {
 			$client_ip = wizard_handle_input('IP:', FILTER_VALIDATE_IP, false, '% Invalid IPv4 or IPv6 address format');
-			$client_fingerprint =  wizard_handle_input('Fingerprint:', FILTER_VALIDATE_REGEXP, array('options'=>array('regexp'=>'/^([a-z0-9]{2}:) {15}([a-z0-9]{2})$/')), '% Invalid Fingerprint [expected: xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx]');
+			$client_fingerprint =  wizard_handle_input('Fingerprint:', FILTER_VALIDATE_REGEXP, array('options'=>array('regexp'=>'/^([a-z0-9]{2}:){15}([a-z0-9]{2})$/')), '% Invalid Fingerprint [expected: xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx]');
 			$rrdp_remote_clients[$client_ip] = $client_fingerprint;
 		}
 	}
@@ -654,7 +654,7 @@ function wizard() {
 		} elseif ($input == 'Y') {
 			$client_ip = wizard_handle_input('IP:', FILTER_VALIDATE_IP, false, '% Invalid IPv4 or IPv6 address format');
 			$client_port = wizard_handle_input('PORT:', FILTER_VALIDATE_REGEXP, array('options'=>array('regexp'=>'/^$|^(102[4-9]|10[3-9]\d|1[1-9]\d{2}|[2-9]\d{3}|[1-5]\d{4}|6[0-4]\d{3}|65[0-4]\d{2}|655[0-2]\d|6553[0-5])$/')), '% Invalid PORT. Range: [1024-65535]');
-			$client_fingerprint =  wizard_handle_input('Fingerprint:', FILTER_VALIDATE_REGEXP, array('options'=>array('regexp'=>'/^([a-z0-9]{2}:) {15}([a-z0-9]{2})$/')), '% Invalid Fingerprint [expected: xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx]');
+			$client_fingerprint =  wizard_handle_input('Fingerprint:', FILTER_VALIDATE_REGEXP, array('options'=>array('regexp'=>'/^([a-z0-9]{2}:){15}([a-z0-9]{2})$/')), '% Invalid Fingerprint [expected: xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx]');
 			$rrdp_remote_proxies[$client_ip] = array('port' => $client_port, 'fingerprint' => $client_fingerprint);
 		}
 	}

--- a/rrdtool-proxy.php
+++ b/rrdtool-proxy.php
@@ -1689,7 +1689,7 @@ function rrdp_cmd__set_cluster($socket, $args) {
 						break;
 					}
 
-					if (filter_var($args[2], FILTER_VALIDATE_REGEXP, array('options' => array('regexp' => '/^([a-z0-9]{2}:) {15}([a-z0-9]{2})$/'))) === false) {
+					if (filter_var($args[2], FILTER_VALIDATE_REGEXP, array('options' => array('regexp' => '/^([a-z0-9]{2}:){15}([a-z0-9]{2})$/'))) === false) {
 						rrdp_system__socket_write($socket, '% Invalid Fingerprint [expected: xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx]' . NL);
 						break;
 					}
@@ -1810,7 +1810,7 @@ function rrdp_cmd__set_client($socket, $args) {
 
 					/* Verify Fingerprint Format */
 					$fingerprint = trim($args[1]);
-					preg_match_all('/^([a-z0-9]{2}:) {15}([a-z0-9]{2})$/', $args[1], $output_array);
+					preg_match_all('/^([a-z0-9]{2}:){15}([a-z0-9]{2})$/', $args[1], $output_array);
 
 					if (isset($output_array[0][0]) && $output_array[0][0] == $args[1]) {
 						/* if the client IP has already been defined, then overwrite its fingerprint */


### PR DESCRIPTION
Good evening! I was attempting to set this up on a local server of mine to test for potential use on a larger deployment when I noticed it absolutely refused to accept my Cacti instance's RSA token. After looking at the regex, it appears that at some point, a space was added in the regex that checks for fingerprints, so instead of matching something like "xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx", it would match something like "xx:(15 spaces)xx". After removing the space from the regex, it began to accept my RSA token again. I've attempted to reflect this change in all the places I could find this regex being used in this pull request.