### PR TITLE
chore: add enterprise Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: develop
+    schedule: {interval: weekly, day: friday}
+    open-pull-requests-limit: 5
+    cooldown: {default-days: 7}
+    groups:
+      github-actions: {patterns: ["*"]}
+    labels: [dependencies, github-actions]
+    commit-message: {prefix: ci, include: scope}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,18 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     target-branch: develop
-    schedule: {interval: weekly, day: friday}
+    schedule:
+      interval: weekly
+      day: friday
     open-pull-requests-limit: 5
-    cooldown: {default-days: 7}
+    cooldown:
+      default-days: 7
     groups:
-      github-actions: {patterns: ["*"]}
-    labels: [dependencies, github-actions]
-    commit-message: {prefix: ci, include: scope}
+      github-actions:
+        patterns:
+          - "*"
+    labels:
+      - dependencies
+    commit-message:
+      prefix: ci
+      include: scope


### PR DESCRIPTION
Adds grouped, cooled-down Dependabot updates with standard ecosystem labels and commit prefixes.